### PR TITLE
Fix a few minor typos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,12 +67,12 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-4 col-md-5" style="padding-top:10px">
-          <p>This project would not be possible without the funding provied by the <a href="https://www.digitalnewsinitiative.com/">Google
+          <p>This project would not be possible without the funding provided by the <a href="https://www.digitalnewsinitiative.com/">Google
             Digital News Initiative</a> and the support of the <a href="https://turing.ac.uk">Alan Turing Institute</a>.
             Thank you!</p>            
           <p>
             All source code is licensed under <a href="https://github.com/the-gamma/thegamma-script/blob/master/LICENSE.md">MIT License</a>
-            and is available on <a href="https://github.com/the-gamma">GitHub</a>. If you have an interesting
+            and is available on <a href="https://github.com/the-gamma">GitHub</a>. If you have any interesting
             project ideas or would like to collaborate, please contact <a href="http://tomasp.net">Tomas Petricek</a> at 
             <a href="https://twitter.com/tomaspetricek">@tomaspetricek</a> or
             <a href="mailto:tomas@tomasp.net">tomas@tomasp.net</a>!

--- a/contributing.md
+++ b/contributing.md
@@ -20,14 +20,14 @@ If you want to run everything locally, you'll need to clone and run the followin
    via [Fable](http://fable.io).
 
  - [**thegamma-sample-web**](https://github.com/the-gamma/thegamma-sample-web) is a minimal web
-   site that you can use for testing your changes. This is a pure node.js web page using the 
+   site that you can use for testing your changes. This is a pure Node.js web page using the 
    [Express](http://expressjs.com/) framework. Live version is [running on 
-   Azure](http://thegamma-sample-web.azurewebsites.net/), but it's a plain node.js web site and will
+   Azure](http://thegamma-sample-web.azurewebsites.net/), but it's a plain Node.js web site and will
    run anywhere.
    
  - [**thegamma-services**](http://thegamma-sample-web.azurewebsites.net/) implements the REST service
    that provides data for the sample visualizations. This is built using F# and [Suave](http://suave.io)
-   and there is a number of scripts. The data source for Olympic medals is implemented
+   and there are a number of scripts. The data source for Olympic medals is implemented
    [here](https://github.com/the-gamma/thegamma-services/blob/master/src/pdata/server.fsx).
 
 ## Getting started with F# &nbsp;

--- a/developers.md
+++ b/developers.md
@@ -28,7 +28,7 @@ npm run start
 ```
 
 The `npm run start` command should start a local server at [localhost:8089](http://localhost:8089/)
-and open a browser with the sample web page. We use node.js just to get the latest version of
+and open a browser with the sample web page. We use Node.js just to get the latest version of
 thegamma-script from npm and serve static files, but there is no server-side processing here
 (in a real web page, you probably also do not want to expose the contents of your 
 `node_modules` in the server, but we do this to make the demo simpler).

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ chart.column(data).legend(position="none")
   <div class="row">
     <div class="col-md-8">
       <h2>Understand and visualize data easily</h2>
-      <p>The Gamma makes it extremely easy to sumamrize data and create useful tables and 
+      <p>The Gamma makes it extremely easy to summarize data and create useful tables and 
         nice visualizations. Thanks to the built-in pivot type provider, the language 
         understands your data source and exposes all operations in an easy to discover
         way. Just type dot and see what columns and operations on them are available!      
@@ -235,7 +235,7 @@ editor<span class="o">.</span>getValue();
           issues, follow the <a href="https://github.com/the-gamma/thegamma-script">project 
           on GitHub</a>.</li>
         <li><a href="/publishing">Publishing data</a>: Create a service that exposes data
-          for the pivot type provider. The service needs to provie a single end-point that
+          for the pivot type provider. The service needs to provide a single end-point that
           can return the data and evaluate simple aggregations.</li>
         <li><a href="/contributing">Contributing</a>: If you are a developer and want to
           help us, this is the place to start. The Gamma is written using the <a href="http://fsharp.org/">awesome


### PR DESCRIPTION
Just fixed a few small typos I spotted reading through the site. 🙂 I also noticed there's some trailing whitespace on most of the markdown files. I left it in case it's deliberate (as happens with markdown), but I'm happy to remove it if you'd like.